### PR TITLE
Initialize default roles automatically on first application startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,12 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <scope>runtime</scope>
-        </dependency>
+		<dependency>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
+			<version>8.4.0</version>
+			<scope>runtime</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/com/sopromadze/blogapi/repository/RoleRepository.java
+++ b/src/main/java/com/sopromadze/blogapi/repository/RoleRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface RoleRepository extends JpaRepository<Role, Long> {
 	Optional<Role> findByName(RoleName name);
+	boolean existsByName(RoleName name);
 }

--- a/src/main/java/com/sopromadze/blogapi/utils/RoleInitializer.java
+++ b/src/main/java/com/sopromadze/blogapi/utils/RoleInitializer.java
@@ -1,0 +1,25 @@
+package com.sopromadze.blogapi.utils;
+
+import com.sopromadze.blogapi.model.role.Role;
+import com.sopromadze.blogapi.model.role.RoleName;
+import com.sopromadze.blogapi.repository.RoleRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoleInitializer implements CommandLineRunner {
+    @Autowired
+    private RoleRepository roleRepository;
+
+    public void run(String... args){
+        if(!roleRepository.existsByName(RoleName.ROLE_ADMIN)){
+            roleRepository.save(new Role(RoleName.ROLE_ADMIN));
+        }
+        if(!roleRepository.existsByName(RoleName.ROLE_USER)){
+            roleRepository.save(new Role(RoleName.ROLE_USER));
+        }
+
+        System.out.println("Role Initialized Successfully");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/blogapi?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
-    username: root
-    password: ??@@suhad@@??
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 spring:
   datasource:
-    url: jdbc:mysql://blogapi-db:3306/blogapi?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/blogapi?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=UTC
     username: root
-    password: root
+    password: ??@@suhad@@??
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
#### Description

This update adds automatic initialization of default roles during the first application startup.

When the application runs for the first time, required roles (e.g., ROLE_USER, ROLE_ADMIN) are automatically inserted into the database if they do not already exist.

This removes the need for manual database role setup.

Fixes # (issue)

#### Type of change
[x] New feature (non-breaking change which adds functionality)

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

- Ran the application locally.
- Verified that roles are automatically created in the database on first startup.
- Restarted the application to confirm roles are not duplicated.

#### Checklist:

[x] I have performed a self-review of my own code
[x] My changes generate no new warnings or errors

